### PR TITLE
🛡️ Sentinel: Sanitize employee names to prevent XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** Dynamic content such as employee names and history entries was injected into the DOM via `innerHTML` without sanitization in `scripts/schedule-modals.ts`.
 **Learning:** Data may bypass initial validation or be rendered in contexts where validation is not applied, so output encoding is required at the rendering boundary.
 **Prevention:** Use a centralized `escapeHTML` utility for cases where HTML structure is required but data must be safe.
+
+## 2025-05-24 - Employee Name Injection Vulnerability
+**Vulnerability:** Employee names retrieved via `EmployeeManager` were injected directly into `innerHTML` across multiple modules (`leaves-summary.ts`, `stations.ts`).
+**Learning:** Even internal data structures (like employee lists) can contain potentially dangerous characters if they are user-editable or synchronized from external sources. The assumption that "internal" data is safe led to widespread `innerHTML` misuse.
+**Prevention:** Always wrap data from `EmployeeManager` in `escapeHTML()` when rendering via `innerHTML`, or use `textContent` for these fields.

--- a/scripts/firebase-config.js
+++ b/scripts/firebase-config.js
@@ -65,7 +65,8 @@ const testFirebaseConfig = {
 };
 
 // Automatyczne wykrywanie środowiska
-const isLocalDevelopment = typeof window !== 'undefined' &&
+const isLocalDevelopment =
+    typeof window !== 'undefined' &&
     (window.location.hostname === 'localhost' ||
         window.location.hostname === '127.0.0.1' ||
         window.location.hostname === '');
@@ -82,8 +83,8 @@ try {
     firestoreDb = initializeFirestore(app, {
         localCache: persistentLocalCache({
             tabManager: persistentMultipleTabManager(),
-            cacheSizeBytes: CACHE_SIZE_UNLIMITED
-        })
+            cacheSizeBytes: CACHE_SIZE_UNLIMITED,
+        }),
     });
     console.log('✅ Firestore offline persistence enabled (multi-tab)');
 } catch (e) {
@@ -96,7 +97,9 @@ try {
         .then(() => console.log('✅ Firestore offline persistence enabled (legacy mode)'))
         .catch((err) => {
             if (err.code === 'failed-precondition') {
-                console.warn('⚠️ Persistence failed: Multiple tabs open. Data will still sync but offline mode limited.');
+                console.warn(
+                    '⚠️ Persistence failed: Multiple tabs open. Data will still sync but offline mode limited.',
+                );
             } else if (err.code === 'unimplemented') {
                 console.warn('⚠️ Persistence not supported in this browser.');
             } else {

--- a/scripts/leaves-summary.ts
+++ b/scripts/leaves-summary.ts
@@ -1,6 +1,7 @@
 // scripts/leaves-summary.ts
 import { EmployeeManager } from './employee-manager.js';
 import { countWorkdays } from './common.js';
+import { escapeHTML } from './utils.js';
 import type { LeaveEntry } from './types';
 
 /**
@@ -105,7 +106,7 @@ export const LeavesSummary: LeavesSummaryAPI = (() => {
             const row = tableBody.insertRow();
             row.dataset.employeeId = employeeId;
             row.innerHTML = `
-                <td>${EmployeeManager.getFullNameById(employeeId)}</td>
+                <td>${escapeHTML(EmployeeManager.getFullNameById(employeeId))}</td>
                 <td>${entitlement}</td>
                 <td class="editable-carried-over" contenteditable="true" 
                     title="Kliknij, aby edytować urlop zaległy"

--- a/scripts/stations.ts
+++ b/scripts/stations.ts
@@ -2,6 +2,7 @@
 import { db as dbRaw, auth as authRaw, FieldValue } from './firebase-config.js';
 import { EmployeeManager } from './employee-manager.js';
 import { MobileZen } from './mobile-zen.js';
+import { escapeHTML } from './utils.js';
 import Hls from 'hls.js';
 
 // Type for Firebase db wrapper (compatible with existing codebase)
@@ -960,7 +961,7 @@ export const Stations: StationsAPI = (() => {
             const employeeButtons = Object.entries(employees)
                 .filter(([_, emp]) => !emp.isHidden)
                 .map(([id, emp]) => {
-                    const name = emp.displayName || `${emp.firstName || ''} ${emp.lastName || ''}`.trim();
+                    const name = escapeHTML(emp.displayName || `${emp.firstName || ''} ${emp.lastName || ''}`.trim());
                     const isCurrent = id === currentEmployeeId;
                     return `
                         <button class="emp-picker-btn ${isCurrent ? 'current' : ''}" data-emp-id="${id}">
@@ -1495,7 +1496,7 @@ export const Stations: StationsAPI = (() => {
             return `${parts[0][0]}.${parts[1][0]}.`.toUpperCase();
         }
 
-        return parts[0].slice(0, 10);
+        return escapeHTML(parts[0].slice(0, 10));
     };
 
     /**
@@ -2453,7 +2454,7 @@ export const Stations: StationsAPI = (() => {
      * Render a station card in 'awaiting start' mode (FREE but Therapy/Massage queued)
      */
     const renderAwaitingStartCard = (room: Room, station: Station, nextEntry: QueueEntry, queueHtml: string): string => {
-        const nextName = EmployeeManager.getNameById(nextEntry.employeeId);
+        const nextName = escapeHTML(EmployeeManager.getNameById(nextEntry.employeeId));
         const addQueueAction = room.type === 'simple' ? 'add-to-queue' : 'show-queue-treatments';
         return `
             <div class="station-card ${room.type === 'simple' ? 'station-simple' : 'station-multi'} awaiting-start" data-station-id="${station.id}">
@@ -2529,7 +2530,7 @@ export const Stations: StationsAPI = (() => {
         }
 
         const queueList = station.queue.map((q, index) => {
-            const empName = EmployeeManager.getNameById(q.employeeId);
+            const empName = escapeHTML(EmployeeManager.getNameById(q.employeeId));
             const treatmentName = getQueueTreatmentLabel(room, station, q);
             const queueEta = formatQueueEta(getQueueWaitSeconds(station, index));
             const isOwn = q.employeeId === currentEmployeeId;
@@ -2588,7 +2589,7 @@ export const Stations: StationsAPI = (() => {
         if (station.status === 'FINISHED' && nextEntry) {
             nextPreviewHtml = `
                 <div class="queue-next">
-                    <i class="fas fa-forward"></i> Następny: ${EmployeeManager.getNameById(nextEntry.employeeId)}
+                    <i class="fas fa-forward"></i> Następny: ${escapeHTML(EmployeeManager.getNameById(nextEntry.employeeId))}
                 </div>
             `;
         }

--- a/tests/context-menu.test.js
+++ b/tests/context-menu.test.js
@@ -39,12 +39,14 @@ describe('context-menu', () => {
         ]);
 
         const target = document.querySelector('.target');
-        target.dispatchEvent(new MouseEvent('contextmenu', {
-            bubbles: true,
-            cancelable: true,
-            clientX: 20,
-            clientY: 30,
-        }));
+        target.dispatchEvent(
+            new MouseEvent('contextmenu', {
+                bubbles: true,
+                cancelable: true,
+                clientX: 20,
+                clientY: 30,
+            }),
+        );
 
         const menu = document.getElementById('contextMenu');
         expect(menu.style.display).toBe('block');
@@ -52,10 +54,12 @@ describe('context-menu', () => {
         expect(document.getElementById('conditionalItem').style.display).toBe('flex');
         expect(onShow).toHaveBeenCalledWith(target, expect.any(MouseEvent));
 
-        document.querySelector('.disabled-target').dispatchEvent(new MouseEvent('contextmenu', {
-            bubbles: true,
-            cancelable: true,
-        }));
+        document.querySelector('.disabled-target').dispatchEvent(
+            new MouseEvent('contextmenu', {
+                bubbles: true,
+                cancelable: true,
+            }),
+        );
 
         expect(document.getElementById('conditionalItem').style.display).toBe('none');
     });
@@ -64,9 +68,7 @@ describe('context-menu', () => {
         setupDom();
         const action = jest.fn();
 
-        initializeContextMenu('contextMenu', '.target', [
-            { id: 'copyItem', action },
-        ]);
+        initializeContextMenu('contextMenu', '.target', [{ id: 'copyItem', action }]);
 
         const target = document.querySelector('.target');
         target.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
@@ -81,11 +83,11 @@ describe('context-menu', () => {
     test('clicking outside hides an open menu', () => {
         setupDom();
 
-        initializeContextMenu('contextMenu', '.target', [
-            { id: 'copyItem', action: jest.fn() },
-        ]);
+        initializeContextMenu('contextMenu', '.target', [{ id: 'copyItem', action: jest.fn() }]);
 
-        document.querySelector('.target').dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+        document
+            .querySelector('.target')
+            .dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
         document.getElementById('outside').click();
 
         expect(document.getElementById('contextMenu').style.display).toBe('none');

--- a/tests/data-validation.test.js
+++ b/tests/data-validation.test.js
@@ -304,7 +304,9 @@ describe('data-validation', () => {
             expect(result.valid).toBe(false);
             expect(result.errors.some((error) => error.includes('Komórka [08:00][0]'))).toBe(true);
             expect(result.errors.some((error) => error.includes('50 znaków'))).toBe(true);
-            expect(result.errors.some((error) => error.includes('isMassage musi być wartością boolean lub null'))).toBe(true);
+            expect(result.errors.some((error) => error.includes('isMassage musi być wartością boolean lub null'))).toBe(
+                true,
+            );
         });
     });
 

--- a/tests/employee-manager.test.js
+++ b/tests/employee-manager.test.js
@@ -65,10 +65,12 @@ describe('EmployeeManager', () => {
     });
 
     test('load() should handle missing data gracefully', async () => {
-        db.collection().doc().get.mockResolvedValue({
-            exists: false,
-            data: () => ({}),
-        });
+        db.collection()
+            .doc()
+            .get.mockResolvedValue({
+                exists: false,
+                data: () => ({}),
+            });
 
         await EmployeeManager.load();
         expect(EmployeeManager.getAll()).toEqual({});
@@ -142,10 +144,7 @@ describe('EmployeeManager', () => {
 
     test('compareEmployees() should sort by composed display key', () => {
         expect(
-            EmployeeManager.compareEmployees(
-                { firstName: 'Żaneta', lastName: 'Nowak' },
-                { displayName: 'Adam' }
-            )
+            EmployeeManager.compareEmployees({ firstName: 'Żaneta', lastName: 'Nowak' }, { displayName: 'Adam' }),
         ).toBeGreaterThan(0);
     });
 

--- a/tests/schedule-helpers.test.js
+++ b/tests/schedule-helpers.test.js
@@ -462,7 +462,13 @@ describe('schedule-helpers', () => {
                 additionalInfo: 'Legacy note',
             };
 
-            updateCellContent(cellState, 'Nowy Pacjent', null, document.createElement('td'), document.createElement('td'));
+            updateCellContent(
+                cellState,
+                'Nowy Pacjent',
+                null,
+                document.createElement('td'),
+                document.createElement('td'),
+            );
 
             expect(cellState.content).toBe('Nowy Pacjent');
             expect(cellState.treatmentStartDate).toBe('2024-01-10');

--- a/tests/scrapped-pdfs.test.js
+++ b/tests/scrapped-pdfs.test.js
@@ -132,9 +132,7 @@ describe('ScrappedPdfs', () => {
     });
 
     test('should show empty search state when nothing matches', async () => {
-        const mockData = [
-            { date: '2023-10-25', type: 'Grafik', title: 'Plan A', url: '#' },
-        ];
+        const mockData = [{ date: '2023-10-25', type: 'Grafik', title: 'Plan A', url: '#' }];
 
         PdfService.fetchAndCachePdfLinks.mockResolvedValue(mockData);
 
@@ -177,7 +175,9 @@ describe('ScrappedPdfs', () => {
 
         expect(document.getElementById('pdfModal').style.display).toBe('flex');
         expect(document.getElementById('pdfOpenNewTabBtn').href).toBe('http://example.com/doc.pdf');
-        expect(document.getElementById('pdfIframe').src).toContain('http://example.com/doc.pdf#navpanes=0&toolbar=0&view=FitH');
+        expect(document.getElementById('pdfIframe').src).toContain(
+            'http://example.com/doc.pdf#navpanes=0&toolbar=0&view=FitH',
+        );
         expect(document.getElementById('pdfModalTitle').textContent).toBe('Plan.pdf');
     });
 });


### PR DESCRIPTION
This PR fixes multiple XSS vulnerabilities in the `leaves-summary` and `stations` modules. Employee names retrieved from `EmployeeManager` (which originates from Firestore) were being injected directly into the DOM using `innerHTML` or template literals without proper sanitization. 

The fix involves:
1. Importing the centralized `escapeHTML` utility from `scripts/utils.ts`.
2. Wrapping all identified `innerHTML` injection points of employee names with `escapeHTML()`.

Affected files:
- `scripts/leaves-summary.ts`: Sanitized `EmployeeManager.getFullNameById()` call in `row.innerHTML`.
- `scripts/stations.ts`: Sanitized multiple `getNameById()` calls and `name` variables used in `innerHTML`, including the employee picker modal and various station card rendering functions.

This change adheres to the security standard of output encoding at the rendering boundary.

---
*PR created automatically by Jules for task [16026997056888061542](https://jules.google.com/task/16026997056888061542) started by @fizjoterapiakalino*